### PR TITLE
feat: 신청한모임리스트(메인/마이페이지)조회 기능 추가, d-day설정 변경, 캘린더 선택 기간 수정

### DIFF
--- a/src/components/party/MyPartyItem.jsx
+++ b/src/components/party/MyPartyItem.jsx
@@ -26,7 +26,7 @@ const MyPartyItem = ({ party }) => {
           <p>디데이 : D-{dDay > 0 ? dDay : 0}</p>
           <p>제목 : {title}</p>
           {/* <p>장소 : {address}</p> 지도 작업후 추가 */}
-          <p>승인여부 : {state === 1 ? '승인대기' : '승인완료'}</p>
+          <p>승인여부: {state === 1 ? '승인완료' : state === 2 ? '승인대기' : ''}</p>
           <p>
             모집인원 : {currentCount} / {totalCount}명
           </p>

--- a/src/components/party/MyPartyList.jsx
+++ b/src/components/party/MyPartyList.jsx
@@ -22,11 +22,11 @@ const MyPartyList = () => {
 
   return (
     <>
-      {myPartyList && (
+      {myPartyList?.length > 0 && (
         <div>
           <h1>신청 모임 리스트</h1>
           <ul>
-            {myPartyList.map(party => (
+            {myPartyList?.map(party => (
               <MyPartyItem key={party.partyId} party={party} />
             ))}
           </ul>

--- a/src/components/party/MyRequestPartyItem.jsx
+++ b/src/components/party/MyRequestPartyItem.jsx
@@ -1,0 +1,62 @@
+import { styled } from 'styled-components';
+import { dDayConvertor } from '../../shared/dDayConvertor';
+import { Link } from 'react-router-dom';
+import { PATH_URL } from '../../shared/constants';
+import moment from 'moment';
+
+const MyRequestPartyItem = ({ party }) => {
+  const {
+    partyId,
+    title,
+    // address,
+    // currentCount,
+    // totalCount,
+    approveStatus,
+    partyDate,
+    memberInfo,
+    state,
+  } = party;
+
+  const dDay = dDayConvertor(partyDate);
+  const formatPartyDate = moment(partyDate).format('YYYY월 MM월 DD일 a HH:mm');
+
+  console.log('approveStatus', approveStatus);
+  return (
+    <PartyItemWrapper>
+      <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`}>
+        <li key={partyId}>
+          <p>승인상태 : {state === 1 ? '승인완료' : '승인대기'}</p>
+          <p>디데이 : D-{dDay > 0 ? dDay : 0}</p>
+          <p>제목 : {title}</p>
+          {/* <p>장소 : {address}</p> 지도 작업후 추가 */}
+          {/* <p>
+            모집인원 : {currentCount} / {totalCount}명
+          </p> */}
+          <p>모임시간 : {formatPartyDate}</p>
+          {memberInfo?.map((member, i) => (
+            <ProfileImageWrapper key={i}>
+              <ProfileImage src={member.profileImage} alt="profileImage" />
+            </ProfileImageWrapper>
+          ))}
+        </li>
+      </Link>
+    </PartyItemWrapper>
+  );
+};
+
+const PartyItemWrapper = styled.div`
+  border: 1px solid black;
+`;
+
+const ProfileImageWrapper = styled.div`
+  display: flex;
+`;
+
+const ProfileImage = styled.img`
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 50%;
+`;
+
+export default MyRequestPartyItem;

--- a/src/components/party/MyRequestPartyList.jsx
+++ b/src/components/party/MyRequestPartyList.jsx
@@ -1,0 +1,64 @@
+import { QueryClient, useQuery } from 'react-query';
+import { getAPI } from '../../api/api';
+import { PARTIES_URL } from '../../shared/constants';
+import MyRequestPartyItem from './MyRequestPartyItem';
+import { useEffect, useState } from 'react';
+
+const MyRequestPartyList = () => {
+  const APPROVE_STATUS_SELECT = [
+    { value: 0, label: '전체' },
+    { value: 1, label: '승인완료' },
+    { value: 2, label: '승인대기' },
+  ];
+  const queryClient = new QueryClient();
+
+  const [approveStatus, setApproveStatus] = useState(APPROVE_STATUS_SELECT[0].value);
+
+  const { data, isLoading, error } = useQuery(['parties', approveStatus], () =>
+    getAPI(`${PARTIES_URL.MY_PARTIES_LIST}?approveStatus=${approveStatus}`),
+  );
+
+  useEffect(() => {
+    queryClient.invalidateQueries('parties');
+  }, [queryClient, approveStatus]);
+
+  const handleSelectChange = e => {
+    const newApproveStatus = e.target.value;
+    if (approveStatus !== newApproveStatus) {
+      setApproveStatus(newApproveStatus);
+    }
+  };
+
+  if (isLoading) {
+    return <div>로딩중입니다.</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+  const requestPartyList = data?.data.data;
+
+  return (
+    <>
+      {requestPartyList?.length > 0 && (
+        <div>
+          <h1>내가 신청한 모임 리스트</h1>
+          <select value={approveStatus} onChange={handleSelectChange}>
+            {APPROVE_STATUS_SELECT.map(status => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          <ul>
+            {requestPartyList?.map(party => (
+              <MyRequestPartyItem key={party.partyId} party={party} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MyRequestPartyList;

--- a/src/components/party/PartyItem.jsx
+++ b/src/components/party/PartyItem.jsx
@@ -3,6 +3,7 @@ import { dDayConvertor } from '../../shared/dDayConvertor';
 import { Link } from 'react-router-dom';
 import { PATH_URL } from '../../shared/constants';
 import moment from 'moment';
+import { useEffect, useMemo } from 'react';
 
 const PartyItem = ({ party }) => {
   const {
@@ -13,12 +14,25 @@ const PartyItem = ({ party }) => {
     totalCount,
     recruitmentStatus,
     partyDate,
+    state,
     memberInfo,
   } = party;
-
   const dDay = dDayConvertor(partyDate);
   const formatPartyDate = moment(partyDate).format('YYYY월 MM월 DD일 a HH:mm');
 
+  const stateMsg = useMemo(() => {
+    if (state === 0) {
+      return '';
+    } else if (state === 1) {
+      return '참여한 모임';
+    } else if (state === 2) {
+      return '승인대기중인 모임';
+    } else {
+      return '거절된 모임';
+    }
+  }, [state]);
+
+  useEffect(() => {}, [stateMsg]);
   return (
     <PartyItemWrapper>
       <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`}>
@@ -28,6 +42,7 @@ const PartyItem = ({ party }) => {
           {/* <p>장소 : {address}</p> 지도 작업후 추가 */}
           <p>모집상태 : {recruitmentStatus ? '모집중' : '모집마감'}</p>
           {/* <p>모임장 : {hostName}</p> */}
+          <p>승인상태 : {stateMsg}</p>
           <p>
             모집인원 : {currentCount} / {totalCount}명
           </p>

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -10,10 +10,10 @@ const Main = () => {
       <Container>
         <MyPartyList />
         <PartyList />
+        <Link to={`${PATH_URL.PARTY_CREATE}`}>
+          <CreateButton>모임 만들기</CreateButton>
+        </Link>
       </Container>
-      <Link to={`${PATH_URL.PARTY_CREATE}`}>
-        <CreateButton>모임 만들기</CreateButton>
-      </Link>
     </Background>
   );
 };

--- a/src/shared/Calendars.jsx
+++ b/src/shared/Calendars.jsx
@@ -2,7 +2,15 @@ import React from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { ko } from 'date-fns/locale';
-import { setHours, setMinutes, startOfDay, endOfDay, addMinutes, isSameDay } from 'date-fns';
+import {
+  setHours,
+  setMinutes,
+  startOfDay,
+  endOfDay,
+  addMinutes,
+  isSameDay,
+  addWeeks,
+} from 'date-fns';
 import { styled } from 'styled-components';
 
 const Calendars = ({ selectedDate, setSelectedDate }) => {
@@ -11,6 +19,8 @@ const Calendars = ({ selectedDate, setSelectedDate }) => {
   const minTime =
     selectedDate && isSameDay(selectedDate, now) ? addMinutes(now, 1) : startOfDay(now);
   const maxTime = setMinutes(setHours(endOfDay(now), 23), 59);
+  const maxDate = addWeeks(now, 2);
+
   return (
     <StDatePicker
       selected={selectedDate}
@@ -22,6 +32,7 @@ const Calendars = ({ selectedDate, setSelectedDate }) => {
       dateFormat="yyyy년 MM월 dd일 a h시 mm분"
       locale={ko}
       minDate={now}
+      maxDate={maxDate}
       minTime={minTime}
       maxTime={maxTime}
     />

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -19,15 +19,16 @@ export const MEMBER_URL = {
 export const PARTIES_URL = {
   DETAIL: '/party', //상세조회
   PARTIES_STATUS_CHANGE: '/party', //수정, 취소, 삭제 기능 통합 URL
-
   PARTIES_LIST: '/parties',
   MY_PARTIES_LIST: '/party/my-party-list',
-  MY_PARTIES_LIST_WAIT: '/party/my-party-list/await',
   PARTIES_DETAIL: '/party/detail',
   PARTIES_APPLICATION: '/party/join',
   PARTIES_CONDITIONS: '/party/accept',
   PARTIES_MAP_INQUIRY: '/map/parties',
   PARTIES_ADD: '/party/new-party',
+  PARTY_MY_REQUEST_PARTY: '/party/request',
+  MY_APPROVE_LIST: 'party/apprve',
+  MY_HOST_LIST: 'party/host-party-list',
 };
 
 export const CHATING_URL = {

--- a/src/shared/dDayConvertor.js
+++ b/src/shared/dDayConvertor.js
@@ -3,6 +3,13 @@ import moment from 'moment';
 export const dDayConvertor = data => {
   const targetDate = moment(data);
   const currentDate = moment();
-  const dDay = targetDate.diff(currentDate, 'days');
+  const hoursDiff = targetDate.diff(currentDate, 'hours');
+  let dDay = 0;
+
+  if (hoursDiff <= 24) {
+    dDay = Math.ceil(moment.duration(targetDate.diff(currentDate)).asDays());
+  } else {
+    dDay = targetDate.diff(currentDate, 'days');
+  }
   return dDay;
 };


### PR DESCRIPTION
## 작업사항

- [src/shared/Calendars.jsx]
  - 모임시간의 캘린더 선택시 2주 이내만 선택가능하도록 수정
- [src/shared/dDayConvertor.js]
  - d-day 24시간일때 d-0으로 출력되는 케이스 수정
- [src/components/party/PartyItem.jsx]
  - 메인페이지 모임리스트에 state 표시되도록
 - [src/components/party/MyPartyList.jsx],[src/components/party/MyPartyItem.jsx]
  - 내가 신청한 모임리스트(메인)승인여부 수정
- [src/components/party/MyRequestPartyList.jsx],[src/components/party/MyRequestPartyItem.jsx],
    [src/shared/constants.js]
  - 내가 신청한 모임리스트(마이페이지) 기능 추가
  - 마이페이지(모임리스트) 경로 추가