### PR TITLE
feat : 로그인시만 상세조회 및 신청모임리스트 조회가능하도록 추가

### DIFF
--- a/src/components/party/PartyItem.jsx
+++ b/src/components/party/PartyItem.jsx
@@ -3,9 +3,13 @@ import { dDayConvertor } from '../../shared/dDayConvertor';
 import { Link } from 'react-router-dom';
 import { PATH_URL } from '../../shared/constants';
 import moment from 'moment';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import Cookies from 'js-cookie';
 
 const PartyItem = ({ party }) => {
+  const [isLogin, setIsLogin] = useState(false);
+  const token = Cookies.get('Access_key');
+
   const {
     partyId,
     title,
@@ -32,10 +36,21 @@ const PartyItem = ({ party }) => {
     }
   }, [state]);
 
-  useEffect(() => {}, [stateMsg]);
+  useEffect(() => {
+    if (token) {
+      setIsLogin(true);
+    }
+  }, [token, stateMsg]);
+
+  const handleLinkClick = e => {
+    if (!isLogin) {
+      e.preventDefault();
+      alert('로그인이 필요합니다.');
+    }
+  };
   return (
     <PartyItemWrapper>
-      <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`}>
+      <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`} onClick={handleLinkClick}>
         <li key={partyId}>
           <p>디데이 : D-{dDay > 0 ? dDay : 0}</p>
           <p>제목 : {title}</p>

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -3,12 +3,23 @@ import MyPartyList from '../components/party/MyPartyList';
 import { Link } from 'react-router-dom';
 import { PATH_URL } from '../shared/constants';
 import { styled } from 'styled-components';
+import Cookies from 'js-cookie';
+import { useEffect, useState } from 'react';
 
 const Main = () => {
+  const [isLogin, setIsLogin] = useState(false); // Example token state
+  const token = Cookies.get('Access_key');
+
+  useEffect(() => {
+    if (token) {
+      setIsLogin(true);
+    }
+  }, [token]);
+
   return (
     <Background>
       <Container>
-        <MyPartyList />
+        {isLogin && <MyPartyList />}
         <PartyList />
         <Link to={`${PATH_URL.PARTY_CREATE}`}>
           <CreateButton>모임 만들기</CreateButton>


### PR DESCRIPTION
## 개요
- 로그인시에만 상세조회 및 모임리스트 조회 가능
## 작업사항
- [src/components/party/PartyItem.jsx]
   - 로그인시에만 메인에서 모임 클릭시 상세조회 가능하도록 추가 
- [src/pages/Main.jsx]
   - 로그인시에만 메인에서 신청모임리스트 조회할 수 있도록 추가 