### PR TITLE
feat : GlobalStyle내 변수 설정, 내가신청한 모임필터링 나오도록 수정

### DIFF
--- a/src/components/party/MyRequestPartyList.jsx
+++ b/src/components/party/MyRequestPartyList.jsx
@@ -39,21 +39,19 @@ const MyRequestPartyList = () => {
   const requestPartyList = data?.data.data;
   return (
     <>
+      <select value={approveStatus} onChange={handleSelectChange}>
+        {APPROVE_STATUS_SELECT.map(status => (
+          <option key={status.value} value={status.value}>
+            {status.label}
+          </option>
+        ))}
+      </select>
       {requestPartyList?.length > 0 ? (
-        <div>
-          <select value={approveStatus} onChange={handleSelectChange}>
-            {APPROVE_STATUS_SELECT.map(status => (
-              <option key={status.value} value={status.value}>
-                {status.label}
-              </option>
-            ))}
-          </select>
-          <ul>
-            {requestPartyList.map(party => (
-              <MyRequestPartyItem key={party.partyId} party={party} />
-            ))}
-          </ul>
-        </div>
+        <ul>
+          {requestPartyList.map(party => (
+            <MyRequestPartyItem key={party.partyId} party={party} />
+          ))}
+        </ul>
       ) : (
         <div>신청한 모임이 없습니다.</div>
       )}

--- a/src/shared/GlobalStyle.js
+++ b/src/shared/GlobalStyle.js
@@ -1,6 +1,79 @@
 import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
+  :root {
+    /* color */
+    --color-primary-25: #FFF5F6;
+    --color-primary-50: #FFF1F3;
+    --color-primary-100: #FFE4E8;
+    --color-primary-200: #FECDD6;
+    --color-primary-300: #FEA3B4;
+    --color-primary-400: #FD6F8E;
+    --color-primary-500: #F63D68;
+    --color-primary-600: #E31B54;
+    --color-primary-700: #E31B54;
+    --color-primary-800: #A11043;
+    --color-primary-900: #89123E;
+    
+    --color-gray-25 : #FFFFFF;
+    --color-gray-50 : #F9FAFB;
+    --color-gray-100 : #F2F4F7;
+    --color-gray-200 : #E4E7EC;
+    --color-gray-300 : #D0D5DD;
+    --color-gray-400 : #98A2B3;
+    --color-gray-500 : #667085;
+    --color-gray-600 : #475467;
+    --color-gray-700 : #344054;
+    --color-gray-800 : #1D2939;
+
+    --color-success-500: #12B76A;
+    --color-error-500 : #F04438;
+    
+    --color-black: #000000;
+    --color-white : #FFFFFF;
+
+    /* font size */
+    --font-large: 48px;
+    --font-medium: 28px;
+    --font-regular: 18px;
+    --font-small: 16px;
+    --font-micro: 14px;
+  }
+
+/* Typography */
+/*
+  h1 {
+    font-size: var(--font-large);
+    font-weight: var(--weight-bold);
+    color: var(--color-black);
+    margin: 16px 0px;
+  }
+  */
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  input:focus {
+    outline: none;
+  }
+
+  button {
+    border: 0 none;
+    background: none;
+    cursor: pointer;
+  }
+  
+  li {
+    list-style: none;
+  }
+  
+  a {
+    text-decoration: none;
+  }
+
+
 `;
 
 export default GlobalStyle;

--- a/src/shared/reset.css
+++ b/src/shared/reset.css
@@ -67,23 +67,4 @@ q:after {
   content: '';
   content: none;
 }
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-input:focus {
-  outline: none;
-}
-button {
-  border: 0 none;
-  background: none;
-  cursor: pointer;
-}
 
-li {
-  list-style: none;
-}
-
-a {
-  text-decoration: none;
-}


### PR DESCRIPTION
## 작업사항
- [src/shared/reset.css],[src/shared/GlobalStyle.js]
    - GlobalStyle 파일 내에 color , font set 정의
    - reset.css내에 li,ul 태그 스타일을 globalStyle로 이동
    
- [src/components/party/MyRequestPartyList.jsx]
    - 내가신청한모임리스트(마이페이지) 필터가 responser값이 없어도 출력되도록 수정
    
## 참고
피그마에서 주로 사용중인 color를 GlobalStyle.jsx파일 내에 변수로 선언했습니다.
자주 쓰이거나 중복되는 변수 값들은 이처럼 정의해서 사용하시면 됩니다.
Styledcomponts 내에서 아래처럼 **var(변수명)입력** 

<사용법>
<img width="312" alt="스크린샷 2023-05-30 18 25 42" src="https://github.com/HH14RS7/SOOLO-FE/assets/38846447/9c33c03c-d4c5-4657-9f8b-5d5ec5e33066">
