### PR TITLE
feat/fix : 주변모임 조회 컴포넌트 분리, 마커 중복 찍히는 현상 수정(resolve #36)

### DIFF
--- a/src/components/map/PartyMapContainer.jsx
+++ b/src/components/map/PartyMapContainer.jsx
@@ -5,10 +5,90 @@ import useGeolocation from '../../hooks/useGeolocation';
 import { styled } from 'styled-components';
 import ReactDOMServer from 'react-dom/server';
 import SelectedPartyItem from './SelectedPartyItem';
-import { formmatedDate } from '../../shared/formattedDate';
+import SearchPartyList from './SearchPartyList';
 const { kakao } = window;
-
-const PartyMapContainer = ({ searchPlace, partyInfo }) => {
+const partyList = [
+  {
+    partyId: 1,
+    title: '밤새 술 먹을 파티 구합니다.',
+    partyDate: '2023-05-29T22:20',
+    recruitmentStatus: false,
+    totalCount: 2,
+    currentCount: 2,
+    latitude: 37.494272356526984,
+    longitude: 127.0280802697825,
+    placeName: '홀릭스',
+    placeAddress: '서울 서초구 서초대로77길 24',
+    distance: 3,
+    stationName: '강남역 신분당선',
+    image:
+      'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+  },
+  {
+    partyId: 2,
+    title: '알쓰들의 모임',
+    partyDate: '2023-05-30T22:20',
+    recruitmentStatus: false,
+    totalCount: 4,
+    currentCount: 2,
+    latitude: 37.5000892164148,
+    longitude: 127.028240773556,
+    placeAddress: '서울 강남구 강남대로96길 15',
+    placeName: '하이퍼서울',
+    distance: 251,
+    stationName: '언주역 2호선',
+    image:
+      'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+  },
+  {
+    partyId: 3,
+    title: '오늘 밤 술 달려봅시다',
+    partyDate: '2023-05-31T22:20',
+    recruitmentStatus: false,
+    totalCount: 4,
+    currentCount: 2,
+    latitude: 37.4939696557259,
+    longitude: 127.027921843719,
+    placeName: '먼데이블루스',
+    placeAddress: '서울 서초구 강남대로53길 11',
+    distance: 252,
+    stationName: '강남역',
+    image:
+      'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+  },
+  {
+    partyId: 4,
+    title: '맛있는 안주랑 같이',
+    partyDate: '2023-06-03T22:20',
+    recruitmentStatus: false,
+    totalCount: 5,
+    currentCount: 2,
+    latitude: 37.495759373328156,
+    longitude: 127.03361964276374,
+    placeName: '언더그라운드',
+    placeAddress: '서울 강남구 역삼로9길 25',
+    distance: 1000,
+    image:
+      'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+  },
+  {
+    partyId: 5,
+    title: '역전할매 ㄱㄱ',
+    partyDate: '2023-06-03T22:20',
+    recruitmentStatus: false,
+    totalCount: 5,
+    currentCount: 2,
+    latitude: 37.29243939383418,
+    longitude: 127.04860740073208,
+    placeName: '역전할머니맥주',
+    placeAddress: '경기 수원시 영통구 센트럴타운로 107',
+    distance: 1003,
+    stationName: '광교중앙역',
+    image:
+      'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+  },
+];
+const PartyMapContainer = ({ searchPlace }) => {
   const location = useLocation();
   const currentloaction = useGeolocation();
   const mapRef = useRef();
@@ -45,7 +125,7 @@ const PartyMapContainer = ({ searchPlace, partyInfo }) => {
     if (searchPlace) {
       ps.keywordSearch(searchPlace, placesSearchCB);
     }
-    const overlayInfos = partyInfo?.map(info => {
+    const overlayInfos = partyList?.map(info => {
       return {
         title: info.placeName,
         lat: info.latitude,
@@ -97,13 +177,13 @@ const PartyMapContainer = ({ searchPlace, partyInfo }) => {
 
       // 마커 클릭시 목록 출력
       kakao.maps.event.addListener(marker, 'click', function () {
-        const selected = partyInfo.find(info => info.partyId === el.partyId);
+        const selected = partyList.find(info => info.partyId === el.partyId);
         setSelectedParty(selected);
       });
 
       // 오버레이 클릭 이벤트
       kakao.maps.event.addListener(customOverlay, 'click', function () {
-        const selected = partyInfo.find(info => info.partyId === el.partyId);
+        const selected = partyList.find(info => info.partyId === el.partyId);
         setSelectedParty(selected);
       });
 
@@ -111,7 +191,7 @@ const PartyMapContainer = ({ searchPlace, partyInfo }) => {
         setSelectedParty(null);
       });
     });
-  }, [partyInfo]);
+  }, [partyList]);
 
   // 현재 위치로 찾기
   const handleCurrentLocation = () => {
@@ -133,27 +213,23 @@ const PartyMapContainer = ({ searchPlace, partyInfo }) => {
         {selectedParty ? (
           <SelectedPartyItem party={selectedParty} />
         ) : (
-          partyInfo?.map(party => (
-            <ListMapper key={party.partyId}>
-              <p>{party.title}</p>
-              <PlaceImage src={party.image} alt="placeImage" />
-              <span>{party.stationName ? party.stationName : party.placeAddress}</span>
-              <span>
-                {party.currentCount}/{party.totalCount}
-              </span>
-              <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
-            </ListMapper>
-          ))
+          <SearchPartyList partyList={partyList} />
+          // partyList?.map(party => (
+          //   <ListMapper key={party.partyId}>
+          //     <p>{party.title}</p>
+          //     <PlaceImage src={party.image} alt="placeImage" />
+          //     <span>{party.stationName ? party.stationName : party.placeAddress}</span>
+          //     <span>
+          //       {party.currentCount}/{party.totalCount}
+          //     </span>
+          //     <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
+          //   </ListMapper>
+          // ))
         )}
       </div>
     </>
   );
 };
-
-const ListMapper = styled.div`
-  border: 1px solid black;
-  font-size: 14px;
-`;
 
 const OverlayWrap = styled.div`
   background-color: var(--color-primary-500);
@@ -173,8 +249,4 @@ const PlaceName = styled.h1`
 
 const OverlayArrow = styled.div``;
 
-const PlaceImage = styled.img`
-  width: 30px;
-  height: 30px;
-`;
 export default PartyMapContainer;

--- a/src/components/map/PartyMapContainer.jsx
+++ b/src/components/map/PartyMapContainer.jsx
@@ -15,12 +15,13 @@ const partyList = [
     recruitmentStatus: false,
     totalCount: 2,
     currentCount: 2,
-    latitude: 37.494272356526984,
-    longitude: 127.0280802697825,
-    placeName: '홀릭스',
-    placeAddress: '서울 서초구 서초대로77길 24',
-    distance: 3,
-    stationName: '강남역 신분당선',
+    latitude: 37.5022613873809,
+    longitude: 127.052438975201,
+    placeName: '센도수산',
+    placeAddress: '서울 강남구 역삼로65길 15',
+    distance: 395,
+    stationName: '선릉역 2호선',
+    placeUrl: 'http://place.map.kakao.com/418495008',
     image:
       'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
   },
@@ -37,6 +38,7 @@ const partyList = [
     placeName: '하이퍼서울',
     distance: 251,
     stationName: '언주역 2호선',
+    placeUrl: 'https://place.map.kakao.com/602523043',
     image:
       'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
   },
@@ -52,6 +54,7 @@ const partyList = [
     placeName: '먼데이블루스',
     placeAddress: '서울 서초구 강남대로53길 11',
     distance: 252,
+    placeUrl: 'https://place.map.kakao.com/27113679',
     stationName: '강남역',
     image:
       'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
@@ -68,6 +71,7 @@ const partyList = [
     placeName: '언더그라운드',
     placeAddress: '서울 강남구 역삼로9길 25',
     distance: 1000,
+    placeUrl: 'https://place.map.kakao.com/300436372',
     image:
       'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
   },
@@ -80,9 +84,10 @@ const partyList = [
     currentCount: 2,
     latitude: 37.29243939383418,
     longitude: 127.04860740073208,
-    placeName: '역전할머니맥주',
+    placeName: '역전할머니맥주 광교중앙점',
     placeAddress: '경기 수원시 영통구 센트럴타운로 107',
     distance: 1003,
+    placeUrl: 'https://place.map.kakao.com/1621313528',
     stationName: '광교중앙역',
     image:
       'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
@@ -93,7 +98,7 @@ const PartyMapContainer = ({ searchPlace }) => {
   const currentloaction = useGeolocation();
   const mapRef = useRef();
   const markersRef = useRef([]);
-  const [selectedParty, setSelectedParty] = useState(null); // Track the selected party
+  const [selectedParty, setSelectedParty] = useState(null);
 
   const latitude = currentloaction.coordinates.latitude; // 위도
   const longitude = currentloaction.coordinates.longitude; // 경도
@@ -112,25 +117,33 @@ const PartyMapContainer = ({ searchPlace }) => {
 
   useEffect(() => {
     const ps = new kakao.maps.services.Places();
+
     const placesSearchCB = (result, status) => {
-      console.log(searchPlace);
       if (status === kakao.maps.services.Status.OK) {
         const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
         mapRef.current.setCenter(coords);
         markersRef.current.forEach(marker => marker.setMap(null));
+      } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
+        alert('검색 결과가 존재하지 않습니다.');
+        return;
+      } else if (status === kakao.maps.services.Status.ERROR) {
+        alert('검색 결과 중 오류가 발생했습니다.');
+        return;
       }
+      // get요청으로 partyList받아와야함
     };
 
     // 검색 키워드 함수 호출
     if (searchPlace) {
       ps.keywordSearch(searchPlace, placesSearchCB);
     }
-    const overlayInfos = partyList?.map(info => {
+
+    const overlayInfos = partyList?.map(party => {
       return {
-        title: info.placeName,
-        lat: info.latitude,
-        lng: info.longitude,
-        partyId: info.partyId,
+        title: party.placeName,
+        lat: party.latitude,
+        lng: party.longitude,
+        partyId: party.partyId,
         yAnchor: 1,
       };
     });
@@ -160,8 +173,6 @@ const PartyMapContainer = ({ searchPlace }) => {
       const customOverlay = new kakao.maps.CustomOverlay({
         position: position,
         content: overlayContent,
-        // content: content,
-        // content: () => content(el.title),
       });
 
       // 마커에 mouseover시 오버레이(가게명)
@@ -177,13 +188,14 @@ const PartyMapContainer = ({ searchPlace }) => {
 
       // 마커 클릭시 목록 출력
       kakao.maps.event.addListener(marker, 'click', function () {
-        const selected = partyList.find(info => info.partyId === el.partyId);
+        const selected = partyList.find(party => party.partyId === el.partyId);
         setSelectedParty(selected);
+        markersRef.current.push(marker);
       });
 
       // 오버레이 클릭 이벤트
       kakao.maps.event.addListener(customOverlay, 'click', function () {
-        const selected = partyList.find(info => info.partyId === el.partyId);
+        const selected = partyList.find(party => party.partyId === el.partyId);
         setSelectedParty(selected);
       });
 
@@ -191,10 +203,18 @@ const PartyMapContainer = ({ searchPlace }) => {
         setSelectedParty(null);
       });
     });
-  }, [partyList]);
+    // unmount될 때 마커 제거
+    return () => {
+      markersRef.current.forEach(marker => {
+        marker.setMap(null);
+      });
+      markersRef.current = [];
+    };
+  }, [searchPlace, partyList]);
 
   // 현재 위치로 찾기
   const handleCurrentLocation = () => {
+    // latitude, longtitude로 get요청해서 받은 목록을 보여줘야 한다.
     const currentLocation = new kakao.maps.LatLng(latitude, longitude);
     mapRef.current.panTo(currentLocation);
   };
@@ -214,17 +234,6 @@ const PartyMapContainer = ({ searchPlace }) => {
           <SelectedPartyItem party={selectedParty} />
         ) : (
           <SearchPartyList partyList={partyList} />
-          // partyList?.map(party => (
-          //   <ListMapper key={party.partyId}>
-          //     <p>{party.title}</p>
-          //     <PlaceImage src={party.image} alt="placeImage" />
-          //     <span>{party.stationName ? party.stationName : party.placeAddress}</span>
-          //     <span>
-          //       {party.currentCount}/{party.totalCount}
-          //     </span>
-          //     <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
-          //   </ListMapper>
-          // ))
         )}
       </div>
     </>

--- a/src/components/map/SearchPartyItem.jsx
+++ b/src/components/map/SearchPartyItem.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import { formmatedDate } from '../../shared/formattedDate';
+import { Link } from 'react-router-dom';
+import { PATH_URL } from '../../shared/constants';
 
 export default function SearchPartyItem({ party }) {
   return (
     <>
       <ItemWrapper>
-        <p>{party.title}</p>
-        <PlaceImage src={party.image} alt="placeImage" />
-        <span>{party.stationName ? party.stationName : party.placeAddress}</span>
-        <span>
-          {party.currentCount}/{party.totalCount}
-        </span>
-        <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
+        <Link to={`${PATH_URL.PARTY_DETAIL}/${party.partyId}`}>
+          <p>{party.title}</p>
+          <PlaceImage src={party.image} alt="placeImage" />
+          <span>{party.stationName ? party.stationName : party.placeAddress}</span>
+          <span>
+            {party.currentCount}/{party.totalCount}
+          </span>
+          <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
+        </Link>
       </ItemWrapper>
     </>
   );

--- a/src/components/map/SearchPartyItem.jsx
+++ b/src/components/map/SearchPartyItem.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import { formmatedDate } from '../../shared/formattedDate';
+
+export default function SearchPartyItem({ party }) {
+  return (
+    <>
+      <ItemWrapper>
+        <p>{party.title}</p>
+        <PlaceImage src={party.image} alt="placeImage" />
+        <span>{party.stationName ? party.stationName : party.placeAddress}</span>
+        <span>
+          {party.currentCount}/{party.totalCount}
+        </span>
+        <p> {formmatedDate(party.partyDate, 'MM.DD · a h:mm')}</p>
+      </ItemWrapper>
+    </>
+  );
+}
+const PlaceImage = styled.img`
+  width: 30px;
+  height: 30px;
+`;
+
+const ItemWrapper = styled.li`
+  border: 1px solid black;
+  font-size: 14px;
+`;

--- a/src/components/map/SearchPartyList.jsx
+++ b/src/components/map/SearchPartyList.jsx
@@ -10,7 +10,15 @@ export default function SearchPartyList({ partyList }) {
         {partyList?.map(party => (
           <SearchPartyItem key={party.partyId} party={party} />
         ))}
+        {partyList?.length > 0 ? (
+          <div>마음에 드는 모임이 없으신가요?</div>
+        ) : (
+          <>
+            <div>주변에 모임이 없습니다</div>
+          </>
+        )}
       </ul>
+      <button>'강남역'에서 모임 만들기</button>
     </>
   );
 }

--- a/src/components/map/SearchPartyList.jsx
+++ b/src/components/map/SearchPartyList.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SearchPartyItem from './SearchPartyItem';
+
+export default function SearchPartyList({ partyList }) {
+  return (
+    <>
+      <span>주변 모임 리스트</span>
+      <span>{partyList?.length}</span>
+      <ul>
+        {partyList?.map(party => (
+          <SearchPartyItem key={party.partyId} party={party} />
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/components/map/SelectedPartyItem.jsx
+++ b/src/components/map/SelectedPartyItem.jsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import { formmatedDate } from '../../shared/formattedDate';
+import { Link } from 'react-router-dom';
+import { PATH_URL } from '../../shared/constants';
 
 export default function SelectedPartyItem({ party }) {
-  console.log(party);
-  const { title, currentCount, totalCount, partyDate, address, image } = party;
+  const { partyId, title, currentCount, totalCount, partyDate, address, image } = party;
+
   return (
     <ListMapper>
-      <div>
-        <p>{title}</p>
-        <span>
-          {currentCount}/{totalCount}
-        </span>
-        <p> {formmatedDate(partyDate, 'MM.DD · a h:mm')}</p>
-        <p>{address}</p>
-        <PlaceImage src={image} alt="placeImage" />
-      </div>
+      <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`}>
+        <div>
+          <p>{title}</p>
+          <span>
+            {currentCount}/{totalCount}
+          </span>
+          <span>{party.stationName ? party.stationName : party.placeAddress}</span>
+
+          <p> {formmatedDate(partyDate, 'MM.DD · a h:mm')}</p>
+          <p>{address}</p>
+          <PlaceImage src={image} alt="placeImage" />
+        </div>
+      </Link>
     </ListMapper>
   );
 }

--- a/src/pages/PartyListMap.jsx
+++ b/src/pages/PartyListMap.jsx
@@ -1,88 +1,8 @@
 import SearchLocation from '../components/map/SearchLocation';
 import PartyMapContainer from '../components/map/PartyMapContainer';
 import { useState } from 'react';
+
 export const PartyListMap = () => {
-  const partyLists = [
-    {
-      partyId: 1,
-      title: '밤새 술 먹을 파티 구합니다.',
-      partyDate: '2023-05-29T22:20',
-      recruitmentStatus: false,
-      totalCount: 2,
-      currentCount: 2,
-      latitude: 37.494272356526984,
-      longitude: 127.0280802697825,
-      placeName: '홀릭스',
-      placeAddress: '서울 서초구 서초대로77길 24',
-      distance: 3,
-      stationName: '강남역 신분당선',
-      image:
-        'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
-    },
-    {
-      partyId: 2,
-      title: '알쓰들의 모임',
-      partyDate: '2023-05-30T22:20',
-      recruitmentStatus: false,
-      totalCount: 4,
-      currentCount: 2,
-      latitude: 37.5000892164148,
-      longitude: 127.028240773556,
-      placeAddress: '서울 강남구 강남대로96길 15',
-      placeName: '하이퍼서울',
-      distance: 251,
-      stationName: '언주역 2호선',
-      image:
-        'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
-    },
-    {
-      partyId: 3,
-      title: '오늘 밤 술 달려봅시다',
-      partyDate: '2023-05-31T22:20',
-      recruitmentStatus: false,
-      totalCount: 4,
-      currentCount: 2,
-      latitude: 37.4939696557259,
-      longitude: 127.027921843719,
-      placeName: '먼데이블루스',
-      placeAddress: '서울 서초구 강남대로53길 11',
-      distance: 252,
-      stationName: '강남역',
-      image:
-        'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
-    },
-    {
-      partyId: 4,
-      title: '맛있는 안주랑 같이',
-      partyDate: '2023-06-03T22:20',
-      recruitmentStatus: false,
-      totalCount: 5,
-      currentCount: 2,
-      latitude: 37.495759373328156,
-      longitude: 127.03361964276374,
-      placeName: '언더그라운드',
-      placeAddress: '서울 강남구 역삼로9길 25',
-      distance: 1000,
-      image:
-        'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
-    },
-    {
-      partyId: 5,
-      title: '역전할매 ㄱㄱ',
-      partyDate: '2023-06-03T22:20',
-      recruitmentStatus: false,
-      totalCount: 5,
-      currentCount: 2,
-      latitude: 37.29243939383418,
-      longitude: 127.04860740073208,
-      placeName: '역전할머니맥주',
-      placeAddress: '경기 수원시 영통구 센트럴타운로 107',
-      distance: 1003,
-      stationName: '광교중앙역',
-      image:
-        'https://images.unsplash.com/photo-1578911373434-0cb395d2cbfb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
-    },
-  ];
   const [place, setPlace] = useState('');
 
   const handlePlaceChange = value => {
@@ -92,10 +12,7 @@ export const PartyListMap = () => {
     <>
       <div>
         <SearchLocation onPlaceChange={handlePlaceChange} />
-        <PartyMapContainer searchPlace={place} partyInfo={partyLists} />
-        <div>주변 모임 리스트 {partyLists?.length}</div>
-        {/* 주변모임리스트의 address와 일치하거나 keyword같은 애들만 나온다. */}
-        {/* 현재 위치로 찾기 버튼을 클릭하면 latitude, longitude 가 움직이며 리스트의 내용들의 마커가 반경 중심으로바뀐다. */}
+        <PartyMapContainer searchPlace={place} />
       </div>
     </>
   );


### PR DESCRIPTION
## 작업사항
- 주변모임 조회 컴포넌트 분리

**[src/components/map/SearchPartyItem.jsx],[src/components/map/SelectedPartyItem.jsx]**
 -  모임정보 클릭시 상세정보로 이동

**[src/components/map/SearchPartyList.jsx]**
 -  하단 모임 문구 조건부 렌더링
 
**[src/components/map/PartyMapContainer.jsx]**
 -  지역 검색시 마커가 중복으로 찍히는 현상 수정