### PR TITLE
feat : 모임수정,조회시 맵좌표 기능 추가 / 좌표 반경 내 모임 마커 출력

### DIFF
--- a/src/components/map/MapContainer.jsx
+++ b/src/components/map/MapContainer.jsx
@@ -172,9 +172,16 @@ const MapContainer = ({ searchPlace, party }) => {
         y: party.latitude,
         x: party.longitude,
         place_name: party.placeName,
+        road_address_name: party.road_address_name,
+        place_url: party.place_url,
       };
-      displayMarker(partyPlace);
+      const stationData = {
+        stationName: party.stationName,
+        distance: party.distance,
+      };
       saveMapData(partyPlace);
+      setStationData(stationData);
+      displayMarker(partyPlace);
     }
   }, [currentloaction, searchPlace]);
 

--- a/src/components/map/PartyMapContainer.jsx
+++ b/src/components/map/PartyMapContainer.jsx
@@ -212,6 +212,16 @@ const PartyMapContainer = ({ searchPlace }) => {
     };
   }, [searchPlace, partyList]);
 
+  const zoomIn = () => {
+    const map = mapRef.current;
+    map.setLevel(map.getLevel() - 1);
+  };
+
+  const zoomOut = () => {
+    const map = mapRef.current;
+    map.setLevel(map.getLevel() + 1);
+  };
+
   // 현재 위치로 찾기
   const handleCurrentLocation = () => {
     // latitude, longtitude로 get요청해서 받은 목록을 보여줘야 한다.
@@ -221,13 +231,22 @@ const PartyMapContainer = ({ searchPlace }) => {
 
   return (
     <>
-      <div
-        id="map"
-        style={{
-          width: '300px',
-          height: '300px',
-        }}
-      />
+      <Map id="map">
+        <ZoomControlContainer>
+          <ZoomButton onClick={zoomIn}>
+            <img
+              src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/ico_plus.png"
+              alt="확대"
+            />
+          </ZoomButton>
+          <ZoomButton onClick={zoomOut}>
+            <img
+              src="https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/ico_minus.png"
+              alt="축소"
+            />
+          </ZoomButton>
+        </ZoomControlContainer>{' '}
+      </Map>
       <button onClick={handleCurrentLocation}>현재 위치로 찾기</button>
       <div>
         {selectedParty ? (
@@ -256,6 +275,39 @@ const PlaceName = styled.h1`
   font-size: var(--font-small);
 `;
 
+const Map = styled.div`
+  // top: 200px;
+  width: 300px;
+  height: 300px;
+  position: relative;
+`;
+
+const ZoomControlContainer = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  z-index: 99;
+`;
+
+const ZoomButton = styled.span`
+  cursor: pointer;
+  padding: 5px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  margin-bottom: 2px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  img {
+    width: 12px;
+    height: 12px;
+  }
+`;
 const OverlayArrow = styled.div``;
 
 export default PartyMapContainer;

--- a/src/components/map/SearchPartyItem.jsx
+++ b/src/components/map/SearchPartyItem.jsx
@@ -10,7 +10,7 @@ export default function SearchPartyItem({ party }) {
       <ItemWrapper>
         <Link to={`${PATH_URL.PARTY_DETAIL}/${party.partyId}`}>
           <p>{party.title}</p>
-          <PlaceImage src={party.image} alt="placeImage" />
+          <PlaceImage src={party.imageUrl} alt="placeImage" />
           <span>{party.stationName ? party.stationName : party.placeAddress}</span>
           <span>
             {party.currentCount}/{party.totalCount}

--- a/src/components/map/SelectedPartyItem.jsx
+++ b/src/components/map/SelectedPartyItem.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { PATH_URL } from '../../shared/constants';
 
 export default function SelectedPartyItem({ party }) {
-  const { partyId, title, currentCount, totalCount, partyDate, address, image } = party;
+  const { partyId, title, currentCount, totalCount, partyDate, address, imageUrl } = party;
 
   return (
     <ListMapper>
@@ -19,7 +19,7 @@ export default function SelectedPartyItem({ party }) {
 
           <p> {formmatedDate(partyDate, 'MM.DD · a h:mm')}</p>
           <p>{address}</p>
-          <PlaceImage src={image} alt="placeImage" />
+          <PlaceImage src={imageUrl} alt="placeImage" />
         </div>
       </Link>
     </ListMapper>

--- a/src/components/party/MyPartyItem.jsx
+++ b/src/components/party/MyPartyItem.jsx
@@ -8,12 +8,13 @@ const MyPartyItem = ({ party }) => {
   const {
     partyId,
     title,
-    // address,
     currentCount,
     totalCount,
     partyDate,
     state,
-    memberInfo,
+    imageUrl,
+    stationName,
+    placeAddress,
   } = party;
 
   const dDay = dDayConvertor(partyDate);
@@ -23,19 +24,16 @@ const MyPartyItem = ({ party }) => {
     <PartyItemWrapper>
       <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`}>
         <li key={partyId}>
-          <p>디데이 : D-{dDay > 0 ? dDay : 0}</p>
-          <p>제목 : {title}</p>
-          {/* <p>장소 : {address}</p> 지도 작업후 추가 */}
-          <p>승인여부: {state === 1 ? '승인완료' : state === 2 ? '승인대기' : ''}</p>
+          <p> D-{dDay > 0 ? dDay : 0}</p>
+          <p>{title}</p>
+          {/* <p>{recruitmentStatus ? '모집중' : '모집마감'}</p> */}
+          {/* <p>승인상태 : {stateMsg}</p> */}
+          <PlaceImage src={imageUrl} alt="placeImage" />
+          <p>{stationName ? stationName : placeAddress}</p>
           <p>
-            모집인원 : {currentCount} / {totalCount}명
+            {currentCount} / {totalCount}
           </p>
-          <p>모임시간 : {formattedDateTime}</p>
-          {memberInfo?.map((member, i) => (
-            <ProfileImageWrapper key={i}>
-              <ProfileImage src={member.profileImage} alt="profileImage" />
-            </ProfileImageWrapper>
-          ))}
+          <p>{formattedDateTime}</p>
         </li>
       </Link>
     </PartyItemWrapper>
@@ -46,15 +44,9 @@ const PartyItemWrapper = styled.div`
   border: 1px solid black;
 `;
 
-const ProfileImageWrapper = styled.div`
-  display: flex;
+const PlaceImage = styled.img`
+  width: 253px;
+  height: 80px;
+  border-radius: 16px;
 `;
-
-const ProfileImage = styled.img`
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 50%;
-`;
-
 export default MyPartyItem;

--- a/src/components/party/PartyDetailInfo.jsx
+++ b/src/components/party/PartyDetailInfo.jsx
@@ -76,7 +76,7 @@ export const PartyDetailInfo = () => {
           <Contents>
             <PartyDetailImg>
               <img
-                src={SojuRoom}
+                src={data?.imageUrl || SojuRoom}
                 alt="partydetail"
                 style={{
                   width: '100%',

--- a/src/components/party/PartyForm.jsx
+++ b/src/components/party/PartyForm.jsx
@@ -11,23 +11,18 @@ import { useRecoilValue } from 'recoil';
 import { mapDataState, stationDataState } from '../../atoms';
 import { putUpdateAPI, postImageAPI } from '../../api/api';
 
-const CreateForm = () => {
+const CreateForm = ({ party }) => {
   const mapData = useRecoilValue(mapDataState);
   const stationData = useRecoilValue(stationDataState);
 
   const PARTICIPANT_COUNT = Array.from({ length: 9 }, (_, i) => ({ value: Number(i + 2) }));
   const navigator = useNavigate();
-  const location = useLocation();
-  const partyId = parseInt(new URLSearchParams(location.search).get('partyId'));
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const party = location.state || {};
-  party.imageUrl =
-    'https://walkingpuppy7.s3.ap-northeast-2.amazonaws.com/S39e3918e3-a1f8-4ccc-ba8e-9cc70797c6d2.jpeg';
   const [previewImage, setPreviewImage] = useState(party.imgUrl || null);
-  const isEdit = !!partyId;
   const imgRef = useRef();
   const noImg = '/img/no-img.jpg';
   const [img, setImg] = useState(noImg);
+  const isEdit = !!party.partyId;
 
   const {
     register,
@@ -63,31 +58,31 @@ const CreateForm = () => {
     validate: value => value.trim().length > 0 || INPUT_MESSAGE.content,
   };
 
-  // 수정모드일때 가져온 값
   useEffect(() => {
     if (isEdit) {
       const partyDate = moment(party.partyDate).format('YYYY-MM-DD HH:mm');
       setSelectedDate(new Date(partyDate));
-
+      // 수정모드일때 가져온 값
       reset({
         title: party.title,
         content: party.content,
         totalCount: party.totalCount,
         partyDate,
-        longitude: party.longitude,
-        placeName: party.placeName,
-        placeAddress: party.placeAddress,
-        placeUrl: party.placeUrl,
-        stationName: party.stationName,
-        distance: party.distance,
         img: party.imageUrl,
+      });
+    } else {
+      reset({
+        title: '',
+        content: '',
+        totalCount: '',
+        img: '',
       });
     }
   }, []);
 
   // 수정
   const updateMutation = useMutation(
-    formData => putUpdateAPI(`${PARTIES_URL.PARTIES_STATUS_CHANGE}/${partyId}`, formData),
+    formData => putUpdateAPI(`${PARTIES_URL.PARTIES_STATUS_CHANGE}/${party.partyId}`, formData),
     {
       onSuccess: response => {
         alert(response.data.msg);

--- a/src/components/party/PartyForm.jsx
+++ b/src/components/party/PartyForm.jsx
@@ -74,7 +74,7 @@ const CreateForm = ({ party }) => {
       reset({
         title: '',
         content: '',
-        totalCount: '',
+        totalCount: 2,
         img: '',
       });
     }

--- a/src/components/party/PartyItem.jsx
+++ b/src/components/party/PartyItem.jsx
@@ -11,16 +11,18 @@ const PartyItem = ({ party }) => {
   const token = Cookies.get('Access_key');
   const navigate = useNavigate();
 
+  console.log(party);
   const {
     partyId,
     title,
-    // address,
     currentCount,
     totalCount,
     recruitmentStatus,
     partyDate,
     state,
-    memberInfo,
+    imageUrl,
+    stationName,
+    placeAddress,
   } = party;
 
   const dDay = dDayConvertor(partyDate);
@@ -51,25 +53,21 @@ const PartyItem = ({ party }) => {
       navigate(PATH_URL.LOGIN);
     }
   };
+
   return (
     <PartyItemWrapper>
       <Link to={`${PATH_URL.PARTY_DETAIL}/${partyId}`} onClick={handleLinkClick}>
         <li key={partyId}>
-          <p>디데이 : D-{dDay > 0 ? dDay : 0}</p>
-          <p>제목 : {title}</p>
-          {/* <p>장소 : {address}</p> 지도 작업후 추가 */}
-          <p>모집상태 : {recruitmentStatus ? '모집중' : '모집마감'}</p>
-          {/* <p>모임장 : {hostName}</p> */}
-          <p>승인상태 : {stateMsg}</p>
+          <p> D-{dDay > 0 ? dDay : 0}</p>
+          <p>{title}</p>
+          {/* <p>{recruitmentStatus ? '모집중' : '모집마감'}</p> */}
+          {/* <p>승인상태 : {stateMsg}</p> */}
+          <PlaceImage src={imageUrl} alt="placeImage" />
+          <p>{stationName ? stationName : placeAddress}</p>
           <p>
-            모집인원 : {currentCount} / {totalCount}명
+            {currentCount} / {totalCount}
           </p>
-          <p>모임시간 : {formattedDateTime}</p>
-          {memberInfo?.map((member, i) => (
-            <div key={i}>
-              <ProfileImage src={member.profileImage} alt="profileImage" />
-            </div>
-          ))}
+          <p>{formattedDateTime}</p>
         </li>
       </Link>
     </PartyItemWrapper>
@@ -80,12 +78,9 @@ const PartyItemWrapper = styled.div`
   border: 1px solid black;
 `;
 
-const ProfileImage = styled.img`
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 50%;
-  display: flex;
+const PlaceImage = styled.img`
+  width: 74px;
+  height: 74px;
+  border-radius: 16px;
 `;
-
 export default PartyItem;

--- a/src/pages/PartyCreate.jsx
+++ b/src/pages/PartyCreate.jsx
@@ -2,10 +2,12 @@ import PartyForm from '../components/party/PartyForm';
 import SearchLocation from '../components/map/SearchLocation';
 import MapContainer from '../components/map/MapContainer';
 import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const PartyCreate = () => {
   const [place, setPlace] = useState('');
-
+  const location = useLocation();
+  const party = location.state || {};
   const handlePlaceChange = value => {
     setPlace(value);
   };
@@ -13,8 +15,8 @@ const PartyCreate = () => {
   return (
     <>
       <SearchLocation onPlaceChange={handlePlaceChange} />
-      <MapContainer searchPlace={place} />
-      <PartyForm />
+      <MapContainer searchPlace={place} party={party} />
+      <PartyForm party={party} />
     </>
   );
 };


### PR DESCRIPTION
## 작업사항
- 반경 내 모임리스트 조회 및 마커 찍기 기능 추가
- 모임 리스트, 신청모임리스트, 상세정보 페이지에서 가게 이미지 출력
- 주변모임 조회페이지 맵의 줌인아웃 버튼 추가
- 모임 수정시 초기좌표 설정 및 기존좌표로 이동하는 이벤트 임시 추가
- 모임 수정시 map관련 data도 저장되도록 수정
- 모임수정: 총인원 2명으로 초기화