### PR TITLE
feat/design : 모임등록,수정 validation 모달 추가 및 모집마감된 리스트 불투명 효과 적용

### DIFF
--- a/src/components/map/CreateMapContainer.jsx
+++ b/src/components/map/CreateMapContainer.jsx
@@ -138,7 +138,7 @@ export default function CreateMapContainer() {
           onConfirmClick={() => goPage('prev')}
         />
       )}
-      {isCloseModalOpen && (
+      {isCloseModalOpen && partyData && (
         <Modal
           type="both"
           message="메인으로 이동하시겠습니까?"

--- a/src/components/map/SearchPartyItem.jsx
+++ b/src/components/map/SearchPartyItem.jsx
@@ -21,7 +21,7 @@ export default function SearchPartyItem({ party }) {
   return (
     <Wrapper>
       <Link to={`${PATH_URL.PARTY_DETAIL}/${party.partyId}`}>
-        <ItemWrapper>
+        <ItemWrapper recuritmentsatus={party.recruitmentStatus ? 1 : 0}>
           <ImageDayInfo>
             <PlaceImage src={party.imageUrl || defaultImg} alt="placeImage" />
             <DdayTag isdday={isdday ? 1 : 0}>
@@ -63,6 +63,7 @@ const ItemWrapper = styled.li`
   gap: 1rem;
   font-size: var(--font-size-regular);
   border-bottom: 1px solid var(--color-gray-100);
+  opacity: ${props => (props.recuritmentsatus ? 1 : 0.6)};
 `;
 
 const ImageDayInfo = styled.div`

--- a/src/components/party/MainInfo.jsx
+++ b/src/components/party/MainInfo.jsx
@@ -1,26 +1,11 @@
-import Cookies from 'js-cookie';
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
-import LoginModal from '../../components/LoginModal';
 
 export default function MainInfo() {
-  const token = Cookies.get('Access_key');
-  const [showModal, setShowModal] = useState(false);
-
-  const goForms = () => {
-    if (token) {
-      window.open('https://forms.gle/PAFUCTugD5KZqAHx6', '_blank');
-    } else {
-      setShowModal(true);
-    }
-  };
-
   return (
     <InfoSection>
-      {showModal && <LoginModal />}
-      <Banner src="/img/banner.png" alt="banner" onClick={goForms} />
-      {/* <InfoTitle>반가워요!🍷 </InfoTitle>
-      <InfoTitle>우리 함께 달려볼까요?</InfoTitle> */}
+      <InfoTitle>반가워요!🍷 </InfoTitle>
+      <InfoTitle>우리 함께 달려볼까요?</InfoTitle>
     </InfoSection>
   );
 }
@@ -30,8 +15,7 @@ const InfoSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  // padding: 36px 1rem; // 배너용 (추후 복구)
-  margin-bottom: 24px; // 배너용(추후 삭제)
+  padding: 36px 1rem;
   display: flex;
 `;
 
@@ -41,8 +25,4 @@ const InfoTitle = styled.div`
   font-weight: var(--font-weight-700);
   letter-spacing: -0.015em;
   text-align: left;
-`;
-
-const Banner = styled.img`
-  cursor: pointer;
 `;

--- a/src/components/party/PartyForm.jsx
+++ b/src/components/party/PartyForm.jsx
@@ -120,7 +120,6 @@ const CreateForm = ({ party }) => {
         setTotalCount(partyData.totalCount);
         setSelectedTime(partyData.selectedTime);
         setSelectedDate(new Date(partyDate));
-        console.log(img);
       }
     }
   }, [partyData]);
@@ -130,7 +129,7 @@ const CreateForm = ({ party }) => {
     formData => putUpdateAPI(`${PARTIES_URL.PARTIES_STATUS_CHANGE}/${party.partyId}`, formData),
     {
       onSuccess: response => {
-        setIsResultModalOpen(true);
+        handleModalOpen('result');
       },
       onError: error => {
         alert(error.message);
@@ -143,7 +142,7 @@ const CreateForm = ({ party }) => {
     formData => postImageAPI(`${PARTIES_URL.PARTIES_ADD}`, formData),
     {
       onSuccess: response => {
-        setIsResultModalOpen(true);
+        handleModalOpen('result');
       },
       onError: error => {
         alert(error.message);
@@ -559,15 +558,6 @@ const Topbar = styled.div`
   border-bottom: 1px solid #f2f4f7;
   background: #fff;
   z-index: 10;
-`;
-
-const TopBackDiv = styled.div`
-  display: flex;
-  position: absolute;
-  align-items: center;
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
 `;
 
 const TopbarName = styled.div`

--- a/src/components/party/PartyForm.jsx
+++ b/src/components/party/PartyForm.jsx
@@ -153,8 +153,10 @@ const CreateForm = ({ party }) => {
 
   // 지하철, 행정구역 정보 조회
   useEffect(() => {
-    getRegionName(latitude, longitude);
-    getStationInfo(latitude, longitude);
+    if (!isEdit) {
+      getRegionName(latitude, longitude);
+      getStationInfo(latitude, longitude);
+    }
   }, [latitude, longitude]);
 
   // 모임 등록 및 수정

--- a/src/components/party/PartyForm.jsx
+++ b/src/components/party/PartyForm.jsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { PATH_URL, PARTIES_URL } from '../../shared/constants';
-import { useMutation } from 'react-query';
+import { useMutation, useQueries, useQueryClient } from 'react-query';
 import { putUpdateAPI, postImageAPI } from '../../api/api';
 import Calendars from '../../shared/Calendars';
 import TimeSlotPicker from '../../shared/TimeSlotPicker';
@@ -16,7 +16,7 @@ import { ReactComponent as Check } from '../../assets/common/check.svg';
 import { ReactComponent as Upload } from '../../assets/common/upload.svg';
 import { ReactComponent as Close } from '../../assets/common/close.svg';
 import { ReactComponent as LeftBack } from '../../assets/chating/LeftBack.svg';
-// import { Modal } from '../../elements/Modal';
+import { Modal } from '../../elements/Modal';
 import { tempPartyData } from '../../atoms';
 
 const CreateForm = ({ party }) => {
@@ -25,6 +25,7 @@ const CreateForm = ({ party }) => {
   const { stationName, distance, getStationInfo } = useGetNearbyStation();
   const setTempPartyData = useSetRecoilState(tempPartyData);
   const partyData = useRecoilValue(tempPartyData);
+  const queryClient = useQueryClient();
 
   const place = location.state || {};
   const isEdit = !!party.partyId;
@@ -43,8 +44,14 @@ const CreateForm = ({ party }) => {
   const minusIcon = '/img/minus.png';
   const defaultImg = '/img/default-image.png';
   const [img, setImg] = useState(defaultImg);
-  const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+  const [formData, setFormData] = useState(null);
+
+  // 모달
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
+  const [isTimeModalOpen, setIsTimeModalOpen] = useState(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  const [isResultModalOpen, setIsResultModalOpen] = useState(false);
 
   const navigate = useNavigate();
 
@@ -74,8 +81,8 @@ const CreateForm = ({ party }) => {
 
   const TITLE_VALIDATE = {
     required: INPUT_MESSAGE.errortitle,
-    minLength: { value: 5, message: INPUT_MESSAGE.errortitle }, // 에러 메시지 추가
-    maxLength: { value: 20, message: '최대 20자까지 입력할 수 있습니다.' }, // 최대 길이 에러 메시지 추가
+    minLength: { value: 5, message: INPUT_MESSAGE.errortitle },
+    maxLength: { value: 20, message: '최대 20자까지 입력할 수 있습니다.' },
     validate: value => {
       const trimmedValue = value.trim();
       return (
@@ -89,7 +96,7 @@ const CreateForm = ({ party }) => {
 
   const CONTENT_VALIDATE = {
     required: INPUT_MESSAGE.errorContent,
-    maxLength: { value: 255, message: '최대 255자까지 입력할 수 있습니다.' }, // 최대 길이 에러 메시지 추가
+    maxLength: { value: 255, message: '최대 255자까지 입력할 수 있습니다.' },
     validate: value => value.trim().length > 0 || INPUT_MESSAGE.errorContent,
   };
 
@@ -123,8 +130,7 @@ const CreateForm = ({ party }) => {
     formData => putUpdateAPI(`${PARTIES_URL.PARTIES_STATUS_CHANGE}/${party.partyId}`, formData),
     {
       onSuccess: response => {
-        // setIsModalOpen(true);
-        alert(response.data.msg);
+        setIsResultModalOpen(true);
       },
       onError: error => {
         alert(error.message);
@@ -137,8 +143,7 @@ const CreateForm = ({ party }) => {
     formData => postImageAPI(`${PARTIES_URL.PARTIES_ADD}`, formData),
     {
       onSuccess: response => {
-        alert(response.data.msg);
-        // setIsModalOpen(true);
+        setIsResultModalOpen(true);
       },
       onError: error => {
         alert(error.message);
@@ -156,11 +161,9 @@ const CreateForm = ({ party }) => {
   const handlePartySubmit = item => {
     const formData = new FormData();
     const formatDate = moment(selectedDate).format('YYYY-MM-DD') + ' ' + selectedTime;
-
     if (!timeValidate()) {
       return;
     }
-
     const data = {
       title: item.title.trim(),
       content: item.content.trim(),
@@ -180,19 +183,17 @@ const CreateForm = ({ party }) => {
     formData.append('data', new Blob([JSON.stringify(data)], { type: 'application/json' }));
     img && formData.append('image', img);
 
-    if (isEdit) {
-      updateMutation.mutate(formData);
-    } else {
-      createMutation.mutate(formData);
-    }
-    reset();
-    setTempPartyData(null);
-    navigate(PATH_URL.MAIN);
+    setFormData(formData);
+    handleModalOpen('save');
+  };
+
+  const handleTimeSelect = time => {
+    setSelectedTime(time);
   };
 
   const timeValidate = () => {
     if (!selectedDate || !selectedTime) {
-      alert('시간을 선택해주세요');
+      handleModalOpen('time');
       return false;
     }
     const currentDate = new Date();
@@ -205,7 +206,7 @@ const CreateForm = ({ party }) => {
       formatSelectedDate === formattTodayDate &&
       parseInt(selectedTime.replace(':', '')) < currentDateTime
     ) {
-      alert('현재 시간 이후로 선택해주세요');
+      handleModalOpen('time');
       return false;
     }
     return true;
@@ -243,40 +244,6 @@ const CreateForm = ({ party }) => {
     }
   };
 
-  const handlePrevClick = () => {
-    if (isEdit) {
-      navigate(PATH_URL.MAIN);
-    } else {
-      const tempData = {
-        selectedDate: moment(selectedDate).format('YYYY-MM-DD'),
-        selectedTime,
-        title,
-        content,
-        totalCount,
-      };
-      setTempPartyData(tempData);
-      console.log(previewImage);
-
-      navigate(PATH_URL.PARTY_MAP_CREATE, { state: place });
-    }
-  };
-
-  // 장소 검색 리스트로 이동
-  const goSearchPlace = () => {
-    const isConfirm = window.confirm('확인시 업로드하신 이미지는 초기화됩니다.');
-    if (isConfirm) {
-      const tempData = {
-        selectedDate: moment(selectedDate).format('YYYY-MM-DD'),
-        selectedTime,
-        title,
-        content,
-        totalCount,
-      };
-      setTempPartyData(tempData);
-      navigate(PATH_URL.PARTY_PLACE_CREATE);
-    }
-  };
-
   const handleIncreaseCount = e => {
     e.preventDefault();
     setTotalCount(totalCount => Math.min(totalCount + 1, 15));
@@ -287,47 +254,80 @@ const CreateForm = ({ party }) => {
     setTotalCount(totalCount => Math.max(totalCount - 1, 2));
   };
 
-  const handleTimeSelect = time => {
-    setSelectedTime(time);
+  const tempSaveData = () => {
+    const tempData = {
+      selectedDate: moment(selectedDate).format('YYYY-MM-DD'),
+      selectedTime,
+      title,
+      content,
+      totalCount,
+    };
+    setTempPartyData(tempData);
   };
 
-  const ExitopenModal = () => {
-    setIsExitModalOpen(true);
+  const goPage = page => {
+    if (page === 'main') {
+      setTempPartyData(null);
+      navigate(PATH_URL.MAIN);
+    } else if (page === 'mapBack') {
+      tempSaveData();
+      navigate(PATH_URL.PARTY_MAP_CREATE, { state: place });
+    } else if (page === 'placeBack') {
+      tempSaveData();
+      navigate(PATH_URL.PARTY_PLACE_CREATE, { state: place });
+    }
   };
 
-  const ExitcloseModal = () => {
-    setIsExitModalOpen(false);
+  const handleModalOpen = action => {
+    if (action === 'close') {
+      setIsCloseModalOpen(prevState => !prevState);
+    } else if (action === 'back' || action === 'placeBack') {
+      setIsModalOpen(prevState => !prevState);
+    } else if (action === 'time') {
+      setIsTimeModalOpen(prevState => !prevState);
+    } else if (action === 'save') {
+      setIsSaveModalOpen(prevState => !prevState);
+    } else if (action === 'result') {
+      setIsResultModalOpen(prevState => !prevState);
+    }
   };
 
-  const handleModalButtonClick = () => {
-    setIsModalOpen(false);
-    navigate(PATH_URL.MAIN);
+  const handleModalConfirmClick = () => {
+    const isValid = handleSubmit(handlePartySubmit)();
+    if (isValid) {
+      if (isEdit) {
+        updateMutation.mutate(formData);
+      } else {
+        createMutation.mutate(formData);
+      }
+      reset();
+      setTempPartyData(null);
+    }
   };
 
   return (
     <Background>
-      {/* {isModalOpen && (
-        <Modal
-          title="모임글이 수정되었습니다."
-          subTitle="모달 부제목"
-          text1="확인"
-          onClick={handleModalButtonClick}
-        />
-      )} */}
       <Container>
         <Topbar>
-          <TopBackDiv>
-            <button onClick={handlePrevClick}>
+          {!isEdit && (
+            <button onClick={() => goPage('mapBack')}>
               <LeftBack />
             </button>
-          </TopBackDiv>
+          )}
           <TopbarName>{isEdit ? '모임 수정하기' : '모임 생성하기'}</TopbarName>
+          <button onClick={() => handleModalOpen('close')}>
+            <Close />
+          </button>
         </Topbar>
         <Contents>
           <PlaceSection>
             <PlaceHeader>
               <Label htmlFor="place">모임 장소</Label>
-              {!isEdit && <ModifyButton onClick={goSearchPlace}>장소 변경하기</ModifyButton>}
+              {!isEdit && (
+                <ModifyButton onClick={() => handleModalOpen('placeBack')}>
+                  장소 변경하기
+                </ModifyButton>
+              )}
             </PlaceHeader>
             <PlaceInfo>
               <LocationIcon src={locationIcon} alt="location" />
@@ -406,7 +406,6 @@ const CreateForm = ({ party }) => {
             </PeopleCountSection>
             <DateContainer>
               <Label htmlFor="partyDate">모임 날짜</Label>
-              {/* <input type="hidden" {...register('partyDate', { value: selectedDate })} /> */}
               <Calendars
                 id="partyDate"
                 selectedDate={selectedDate}
@@ -427,7 +426,6 @@ const CreateForm = ({ party }) => {
               <Label htmlFor="img">이미지 업로드(선택)</Label>
               <PlaceImageWrapper>
                 <PlaceImage src={previewImage || party.imageUrl || defaultImg} alt="PlaceImage" />
-                {/* 업로드버튼 */}
                 <UploadButton onClick={handleUploadClick}>
                   <UploadIcon />
                   <FileInput
@@ -446,32 +444,6 @@ const CreateForm = ({ party }) => {
                       : '이미지 변경하기'}
                   </UploadMsg>
                 </UploadButton>
-                {/* <ButtonContainer>
-                  <ImgModifyButton onClick={handleUploadClick}>
-                    <UploadIcon />
-                    <FileInput
-                      type="file"
-                      accept="image/*"
-                      id="img"
-                      name="img"
-                      ref={imgRef}
-                      onChange={handleFileChange}
-                    />
-                    <UploadMsg>이미지 변경하기</UploadMsg>
-                  </ImgModifyButton>
-                  <ImgModifyButton onClick={handleDeleteClick}>
-                    <CloseIcon />
-                    <FileInput
-                      type="file"
-                      accept="image/*"
-                      id="img"
-                      name="img"
-                      ref={imgRef}
-                      onChange={handleFileChange}
-                    />
-                    <UploadMsg>이미지 삭제하기</UploadMsg>
-                  </ImgModifyButton>
-                </ButtonContainer> */}
               </PlaceImageWrapper>
               <ModifyInfo>
                 <InfoMsg> {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}</InfoMsg>
@@ -493,7 +465,6 @@ const CreateForm = ({ party }) => {
               </ImageInfo>
             </ImageInfoSection>
             <ButtonWrapper>
-              {/* <button onClick={handlePrevClick}>취소하기</button> */}
               <PostButton type="submit">
                 {isEdit ? '모임글 수정하기' : '모임글 게시하기'}
               </PostButton>
@@ -501,6 +472,60 @@ const CreateForm = ({ party }) => {
           </FormContainer>
         </Contents>
       </Container>
+      {isModalOpen && (
+        <Modal
+          type="both"
+          message="장소를 변경하시겠습니까?"
+          subMessage="업로드하신 이미지는 임시저장되지 않습니다."
+          cancelName="머무르기"
+          confirmName="변경하기"
+          onCancelClick={() => handleModalOpen('back')}
+          onConfirmClick={() => goPage('placeBack')}
+        />
+      )}
+      {isCloseModalOpen && (
+        <Modal
+          type="both"
+          message={isEdit ? '모임 수정을 취소하시겠습니까?' : '모임 생성을 취소하시겠습니까?'}
+          subMessage={
+            isEdit ? '나가면 수정사항이 저장되지 않습니다.' : '나가면 작성사항이 저장되지 않습니다.'
+          }
+          cancelName="머무르기"
+          confirmName="나가기"
+          onCancelClick={() => handleModalOpen('close')}
+          onConfirmClick={() => goPage('main')}
+        />
+      )}
+      {isTimeModalOpen && (
+        <Modal
+          type="single"
+          message={
+            selectedTime
+              ? '모임 시간은 현재 시간 이후로 선택해주세요.'
+              : '모임 시간을 선택해주세요.'
+          }
+          confirmName="확인"
+          onConfirmClick={() => handleModalOpen('time')}
+        />
+      )}
+      {isSaveModalOpen && !Object.keys(errors).length && (
+        <Modal
+          type="both"
+          message={isEdit ? '모임글을 수정하시겠습니까?' : '모임글을 게시하시겠습니까?'}
+          cancelName="머무르기"
+          confirmName={isEdit ? '수정하기' : '게시하기'}
+          onCancelClick={() => handleModalOpen('save')}
+          onConfirmClick={() => handleModalConfirmClick()}
+        />
+      )}
+      {isResultModalOpen && (
+        <Modal
+          type="single"
+          message={isEdit ? '모임글이 수정되었습니다.' : '모임글이 게시되었습니다.'}
+          confirmName="확인"
+          onConfirmClick={() => goPage('main')}
+        />
+      )}
     </Background>
   );
 };

--- a/src/components/party/PartyItem.jsx
+++ b/src/components/party/PartyItem.jsx
@@ -20,7 +20,7 @@ const PartyItem = ({ party }) => {
   return (
     <>
       <Link to={`${PATH_URL.PARTY_DETAIL}/${party.partyId}`}>
-        <ItemWrapper>
+        <ItemWrapper recuritmentsatus={party.recruitmentStatus ? 1 : 0}>
           <ImageDayInfo>
             <PlaceImage src={party.imageUrl || defaultImg} alt="placeImage" />
             <DdayTag isdday={isdday ? 1 : 0}>
@@ -62,6 +62,7 @@ const ItemWrapper = styled.li`
   height: 101px;
   font-size: var(--font-size-regular);
   border-bottom: 1px solid var(--color-gray-100);
+  opacity: ${props => (props.recuritmentsatus ? 1 : 0.6)};
 `;
 
 const PlaceImage = styled.img`

--- a/src/components/party/PartyList.jsx
+++ b/src/components/party/PartyList.jsx
@@ -56,6 +56,8 @@ const PartyList = () => {
     queryClient.invalidateQueries('getPartyList');
   }, [recruitmentStatus, queryClient]);
 
+  useEffect(() => {}, [partyList]);
+
   useEffect(() => {
     if (inView) {
       fetchNextPage();

--- a/src/components/party/PartyList.jsx
+++ b/src/components/party/PartyList.jsx
@@ -218,7 +218,7 @@ const ListBottomSection = styled.section`
   align-items: center;
   padding: 2rem 0;
   gap: 6px;
-  margin-bottom: 70px;
+  padding-bottom: 90px;
 `;
 
 /* BottomInfoSection */

--- a/src/components/party/PartyList.jsx
+++ b/src/components/party/PartyList.jsx
@@ -51,6 +51,7 @@ const PartyList = () => {
   const [ref, inView] = useInView({
     threshold: 0,
   });
+
   useEffect(() => {
     queryClient.invalidateQueries('getPartyList');
   }, [recruitmentStatus, queryClient]);
@@ -217,7 +218,7 @@ const ListBottomSection = styled.section`
   align-items: center;
   padding: 2rem 0;
   gap: 6px;
-  padding-bottom: 120px; // 무한스크롤 구현 후 제거
+  margin-bottom: 70px;
 `;
 
 /* BottomInfoSection */


### PR DESCRIPTION
## 작업사항
- 모임 등록/수정 후 모달 확인시 메인에서 자동으로 리렌더링 되도록 useEffect조건 partyList 추가
- 진행중 모임 UI위치 수정
- 지하철,카테고리 카카오 api호출->모임등록시만 요청
- 모임등록수정 폼 탭바, validation 모달 추가
- 모임생성맵 모달 조건 변경
- 메인배너 설문조사 기간 종료로 삭제 후 원복
- 진행중모임,위치검색모임(마감된 모임은 불투명 효과 적용) 및 ui 위치 수정